### PR TITLE
Feat/adapt object context menu

### DIFF
--- a/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
+++ b/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
@@ -165,6 +165,9 @@ public class ObjectContextMenu extends ContextMenu {
 		mergeProperties.setOnAction(e -> actions.openMergePropertiesDialog(object));
 		getItems().add(mergeProperties);
 		
+		MenuItem assignToGlobalVariable = new MenuItem("Assign to global Var");
+		assignToGlobalVariable.setOnAction(e -> actions.assignToGlobalVariable(object));
+		getItems().add(assignToGlobalVariable);
 	}
 
 	private void addRunMenu() {

--- a/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
+++ b/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
@@ -79,11 +79,9 @@ public class ObjectContextMenu extends ContextMenu {
 		
 		MenuItem changeParentItem = new MenuItem("Change parent (Superclass)");
 		changeParentItem.setOnAction(e -> actions.changeParentsDialog(object));
-		getItems().add(changeParentItem);
 		
 		MenuItem browseInstanceItem = new MenuItem("Browse Instances");
 		browseInstanceItem.setOnAction(e -> actions.showObjectBrowser(object));
-		getItems().add(browseInstanceItem);
 		
 //		MenuItem changeLevelItem = new MenuItem("Change level");
 //		changeLevelItem.setOnAction(e -> actions.changeLevelDialog(object, PropertyType.Class));
@@ -151,8 +149,8 @@ public class ObjectContextMenu extends ContextMenu {
 		//add all items, that are used for all Objects
 		getItems().addAll(slotMenu, associationInstanceMenu, editConcreteSyntaxItem);			
 		//add items, that are used only for Objects that are not on level 0
-		if (!object.getLevel().isEqual(0)) getItems().addAll(attributeMenu, associationMenu, operationMenu, constraintMenu, delegationMenu);
-		
+		if (!object.getLevel().isEqual(0)) getItems().addAll(changeParentItem, browseInstanceItem, attributeMenu, associationMenu, operationMenu, constraintMenu, delegationMenu);
+
 		addRunMenu();
 		
 		addNewMenuItem(this, "Hide", e -> {

--- a/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
+++ b/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
@@ -149,9 +149,9 @@ public class ObjectContextMenu extends ContextMenu {
 		});
 		
 		//add all items, that are used for all Objects
-		getItems().addAll(attributeMenu, slotMenu, associationInstanceMenu, editConcreteSyntaxItem);			
+		getItems().addAll(slotMenu, associationInstanceMenu, editConcreteSyntaxItem);			
 		//add items, that are used only for Objects that are not on level 0
-		if (!object.getLevel().isEqual(0)) getItems().addAll(associationMenu, operationMenu, constraintMenu, delegationMenu);
+		if (!object.getLevel().isEqual(0)) getItems().addAll(attributeMenu, associationMenu, operationMenu, constraintMenu, delegationMenu);
 		
 		addRunMenu();
 		

--- a/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
+++ b/src/tool/clients/fmmlxdiagrams/menus/ObjectContextMenu.java
@@ -148,16 +148,10 @@ public class ObjectContextMenu extends ContextMenu {
 			}
 		});
 		
-		
-		
-		getItems().addAll(attributeMenu, 
-				associationMenu, 
-				operationMenu, 
-				constraintMenu, 
-				delegationMenu, 
-				slotMenu, 
-				associationInstanceMenu, 
-				editConcreteSyntaxItem);
+		//add all items, that are used for all Objects
+		getItems().addAll(attributeMenu, slotMenu, associationInstanceMenu, editConcreteSyntaxItem);			
+		//add items, that are used only for Objects that are not on level 0
+		if (!object.getLevel().isEqual(0)) getItems().addAll(associationMenu, operationMenu, constraintMenu, delegationMenu);
 		
 		addRunMenu();
 		


### PR DESCRIPTION
Cleaned the ObjectsContextMenu. For Objects on level 0 only relevant menus are presented.
Added Menu for assigning an object to a global variable.
