### PR TITLE
AddAttributeDialog; added a checkbox to switch between primitive and non-primitiv data types

### DIFF
--- a/src/tool/clients/fmmlxdiagrams/dialogs/AddAttributeDialog.java
+++ b/src/tool/clients/fmmlxdiagrams/dialogs/AddAttributeDialog.java
@@ -3,6 +3,7 @@ package tool.clients.fmmlxdiagrams.dialogs;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.control.ButtonBar.ButtonData;
@@ -14,6 +15,8 @@ import tool.clients.fmmlxdiagrams.dialogs.stringandvalue.StringValue;
 
 import java.util.*;
 
+// FH 15.05.2024 - Updated dialog to allow selection of only primitive data types
+// FH 15.05.2024 - Added exception handling on front-end regarding data type input
 
 public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> {
 
@@ -34,6 +37,7 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 	private CheckBox isIntrinsicBox;
 	private CheckBox isIncompleteBox;
 	private CheckBox isOptionalBox;
+	private CheckBox showNonPrimitive;
 
 	private AbstractPackageViewer diagram;
 	private FmmlxObject selectedObject;
@@ -41,6 +45,8 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 	private Multiplicity multiplicity = Multiplicity.MANDATORY;
 	
 	private Vector<String> types;
+	private Vector<String> primitiveTypes;
+	private Vector<FmmlxObject> diagramObjects;
 
 	public AddAttributeDialog(final AbstractPackageViewer diagram) {
 		this(diagram, null);
@@ -50,6 +56,8 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 		super();
 		this.diagram = diagram;
 		types = diagram.getAvailableTypes();
+		primitiveTypes = new Vector<String>(List.of("Boolean", "Integer", "Float", "String", "Date"));
+		diagramObjects = diagram.getObjectsReadOnly();
 
 		DialogPane dialogPane = getDialogPane();
 		this.selectedObject = selectedObject;
@@ -123,6 +131,31 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 
 	private boolean validateType() {
 		Label errorLabel = getErrorLabel();
+		// used for checking whether the type is correct
+		Vector<String> classNames = new Vector<>();
+		Vector<String> validTypes = new Vector<>();
+		
+		// FH check for valid type
+		if (!(showNonPrimitive.isSelected())) {
+			// if primitive is selected, only those types are valid
+			validTypes.addAll(primitiveTypes);
+
+		} else {
+			// if non primitive types are allowed, classnames and all types are valid
+			// classnames can be used as types for attributes
+			for (FmmlxObject o : diagramObjects) {
+				if (o.getLevel().getMinLevel() > 0) {
+					classNames.add(o.toString());
+				}
+			}
+			validTypes.addAll(classNames);
+			validTypes.addAll(types);
+		}
+		// check whether entered type is valid
+		if (!validTypes.contains(getComboBoxStringValue(typeComboBox))) {
+			errorLabel.setText(StringValue.ErrorMessage.selectCorrectType);
+			return false;
+		}
 
 		if (getComboBoxStringValue(typeComboBox) == null || getComboBoxStringValue(typeComboBox).length() < 1) {
 			errorLabel.setText(StringValue.ErrorMessage.selectType);
@@ -142,7 +175,6 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 		errorLabel.setText("");
 		return true;
 	}
-
 
 	private boolean validateName() {
 		Label errorLabel = getErrorLabel();
@@ -166,10 +198,12 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 		levelLabel = new Label(StringValue.LabelAndHeaderTitle.level);
 		typeLabel = new Label(StringValue.LabelAndHeaderTitle.type);
 		multiplicityLabel = new Label(StringValue.LabelAndHeaderTitle.Multiplicity);
+		showNonPrimitive = new CheckBox("Show non primitive data types");
 		isIntrinsicLabel = new Label("intrinsic");
 		isIncompleteLabel = new Label("incomplete");
 		isOptionalLabel = new Label("optional");
-
+		
+		ObservableList<String> primitiveTypeList = FXCollections.observableArrayList(primitiveTypes);
 		ObservableList<String> typeList = FXCollections.observableArrayList(types);
 
 		nameTextField = new TextField();
@@ -185,7 +219,11 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 //		}
 //		levelComboBox.getSelectionModel().selectLast();
 //		if(selectedObject.getLevel().isContingentLevelClass()) levelComboBox.setEditable(true);
-		typeComboBox = new ComboBox<>(typeList);
+		
+		// initial values for the combobox are only primitive types, selecting the checkbox can change that
+		typeComboBox = new ComboBox<>(primitiveTypeList);
+		
+		
 		typeComboBox.setEditable(true);
 		multiplicityButton = new Button();
 		multiplicityButton.setText(multiplicity.getClass().getSimpleName());
@@ -196,6 +234,7 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 		
 
 		classTextField.setPrefWidth(COLUMN_WIDTH);
+		showNonPrimitive.setPrefWidth(COLUMN_WIDTH);
 		levelComboBox.setPrefWidth(COLUMN_WIDTH);
 		typeComboBox.setPrefWidth(COLUMN_WIDTH);
 		multiplicityButton.setPrefWidth(COLUMN_WIDTH);
@@ -208,24 +247,25 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 		grid.add(nameLabel, 0, 0);
 		grid.add(classLabel, 0, 1);
 		if(!diagram.getUMLMode()) {
-		grid.add(levelLabel, 0, 2);
-		grid.add(multiplicityLabel, 0, 4);
-		grid.add(isIntrinsicLabel, 0, 6);
-		grid.add(isIncompleteLabel, 0, 7);
-		grid.add(isOptionalLabel, 0, 8);
-		grid.add(levelComboBox, 1, 2);
-		grid.add(isIntrinsicBox, 1, 6);
-		grid.add(isIncompleteBox, 1, 7);
-		grid.add(isOptionalBox, 1, 8);
+		grid.add(levelLabel, 0, 3);
+		grid.add(multiplicityLabel, 0, 5);
+		grid.add(isIntrinsicLabel, 0, 7);
+		grid.add(isIncompleteLabel, 0, 8);
+		grid.add(isOptionalLabel, 0, 9);
+		grid.add(levelComboBox, 1, 3);
+		grid.add(isIntrinsicBox, 1, 7);
+		grid.add(isIncompleteBox, 1, 8);
+		grid.add(isOptionalBox, 1, 9);
 		}
-		grid.add(typeLabel, 0, 3);
+		grid.add(typeLabel, 0, 4);
 
 		
 		grid.add(nameTextField, 1, 0);
 		grid.add(classTextField, 1, 1);
-		grid.add(typeComboBox, 1, 3);
-		grid.add(multiplicityButton, 1, 4);
-		grid.add(displayMultiplicityLabel, 1, 5);
+		grid.add(showNonPrimitive,1,2);
+		grid.add(typeComboBox, 1, 4);
+		grid.add(multiplicityButton, 1, 5);
+		grid.add(displayMultiplicityLabel, 1, 6);
 		
 		
 		
@@ -248,6 +288,19 @@ public class AddAttributeDialog extends CustomDialog<AddAttributeDialog.Result> 
 //		addNodesToGrid(labelNode, 0);
 //		addNodesToGrid(editorNode, 1);
 		
+		// Define an event handler for changes in the state of the checkbox showNonPrimitives
+		EventHandler<ActionEvent> changedCheckboxPrimitiveEvent = new EventHandler<ActionEvent>() {
+		    public void handle(ActionEvent e) {
+		        // switch of the contents of the typecombobox
+		        if (showNonPrimitive.isSelected()) {
+		            typeComboBox.setItems(typeList);
+		        } else {
+		        	 	typeComboBox.setItems(primitiveTypeList);
+		        }
+		    }
+		};
+		// Attach the event handler to the checkbox
+		showNonPrimitive.setOnAction(changedCheckboxPrimitiveEvent);
 	}
 
 	private void showMultiplicityDialog() {

--- a/src/tool/clients/fmmlxdiagrams/dialogs/stringandvalue/StringValue.java
+++ b/src/tool/clients/fmmlxdiagrams/dialogs/stringandvalue/StringValue.java
@@ -11,6 +11,7 @@ public class StringValue {
 		public static final String selectLevel = "Select Level!";
 		public static final String selectNewLevel = "Select new Level!";
 		public static final String selectType = "Select Type!";
+		public static final String selectCorrectType = "Select a valid type!";
 		public static final String selectNewType = "Select New Type!";
 		public static final String selectAnotherType = "Select Another Type!";
 		public static final String selectNewParent = "Select New Parent!";


### PR DESCRIPTION
Two new features:
1) Updated add attribute dialog to allow selection of only primitive data types
2) Added exception handling on front-end regarding data type input based on the checkbox value, i.e., if only primitive data types are displayed, only primitive data types can be used; if the checkbox is selected all valid data types can be used

- [X] Feature
- [X] BugFix

This branch should be deleted after the changes were pulled [YES]
